### PR TITLE
Add Ability to Harvest all PubDate Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,16 @@ This function will return list of dictionaries, where each element contains:
 - `authors`: authors, each separated by `;`
 - `mesh_terms`: list of MeSH terms, each separated by `;`
 - `keywords`: list of keywords, each separated by `;`
-- `year`: Publication year
+- `pubdate`: Publication date. Defaults to year information only.
 
 ```python
 dicts_out = pp.parse_medline_xml('data/medline16n0902.xml.gz') # return list of dictionary
+```
+
+Try to extract month and day information from PubDate as well:
+
+```python
+dicts_out = pp.parse_medline_xml('data/medline16n0902.xml.gz', year_info_only=False)  
 ```
 
 #### Parse Medline Grant ID

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -185,8 +185,8 @@ def date_extractor(journal, year_info_only):
         if not year_info_only:
             if issue_date.find('Month') is not None:
                 month = month_or_day_formater(issue_date.find('Month').text)
-            if issue_date.find('Day') is not None:
-                day = month_or_day_formater(issue_date.find('Day').text)
+                if issue_date.find('Day') is not None:
+                    day = month_or_day_formater(issue_date.find('Day').text)
     elif issue_date.find('MedlineDate') is not None:
         year_text = issue_date.find('MedlineDate').text
         year = year_text.split(' ')[0]

--- a/pubmed_parser/utils.py
+++ b/pubmed_parser/utils.py
@@ -1,4 +1,6 @@
+import calendar
 import collections
+from time import strptime
 from six import string_types
 from lxml import etree
 from itertools import chain
@@ -75,3 +77,32 @@ def _recur_children(node):
                  [_recur_children(c) for c in node.getchildren()] +
                  [node.tail or ''])
         return parts
+
+
+def month_or_day_formater(month_or_day):
+    """
+    Parameters
+    ----------
+    month_or_day: str or int
+        must be one of the following:
+            (i)  month: a three letter month abbreviation, e.g., 'Jan'.
+            (ii) day: an integer.
+
+    Returns
+    -------
+    numeric: str
+        a month of the form 'MM' or a day of the form 'DD'.
+        Note: returns None if:
+            (a) the input could not be mapped to a known month abbreviation OR
+            (b) the input was not an integer (i.e., a day).
+    """
+    if month_or_day.replace(".", "") in filter(None, calendar.month_abbr):
+        to_format = strptime(month_or_day.replace(".", ""),'%b').tm_mon
+    elif month_or_day.strip().isdigit() and "." not in str(month_or_day):
+        to_format = int(month_or_day.strip())
+    else:
+        return None
+
+    return ("0" if to_format < 10 else "") + str(to_format)
+
+


### PR DESCRIPTION
This is a fantastic tool. However, year information alone is often insufficient when performing some types of analyses, e.g., time series analyses. This fix removes that limitation.

   