### PR TITLE
Revert paragraphs xpath change

### DIFF
--- a/pubmed_parser/pubmed_oa_parser.py
+++ b/pubmed_parser/pubmed_oa_parser.py
@@ -264,7 +264,7 @@ def parse_pubmed_paragraph(path, all_paragraph=False):
     pmid = dict_article_meta['pmid']
     pmc = dict_article_meta['pmc']
 
-    paragraphs = tree.xpath('.//body.//p')
+    paragraphs = tree.xpath('//body//p')
     dict_pars = list()
     for paragraph in paragraphs:
         paragraph_text = stringify_children(paragraph)


### PR DESCRIPTION
It appears that the change to the paragraphs introduced in this commit #57 caused issue #59 
Reverting that line back to how it was before #57 fixed the problem with parsing paragraphs.
Might be worth reviewing the discussion in #57 on relative paths.