### PR TITLE
Fix: Improved serialzation

### DIFF
--- a/pubmed_parser/__init__.py
+++ b/pubmed_parser/__init__.py
@@ -12,7 +12,7 @@ from .pubmed_oa_parser import (
     parse_pubmed_caption,
     parse_pubmed_table,
 )
-from .medline_parser import parse_medline_xml, parse_medline_grant_id
+from .medline_parser import parse_medline_xml, parse_medline_grant_id, parse_medline_xml_abcam
 from .pubmed_web_parser import (
     parse_xml_web,
     parse_citation_web,

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -782,7 +782,7 @@ def parse_medline_xml(
     return article_list
 
 
-def get_medline_tree(path, to_string=False):
+def get_medline_tree(path, to_string=False, encoding='utf-8'):
     """Initial parsing of the xml file tree. Finds all the articles.
 
     Parameters
@@ -792,6 +792,9 @@ def get_medline_tree(path, to_string=False):
 
     to_string: bool
         If True, return a list of string elements
+
+    encoding: str
+        How to encode the elements if `to_string=True`
 
     Return
     ------
@@ -804,7 +807,7 @@ def get_medline_tree(path, to_string=False):
         medline_citations = tree.findall("//PubmedArticle")
 
     if to_string:
-        return [lxml.etree.tostring(elem) for elem in medline_citations]
+        return [lxml.etree.tostring(elem, encoding=encoding) for elem in medline_citations]
 
     return medline_citations
 

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -325,7 +325,7 @@ def parse_author_affiliation(medline):
     ----------
     medline: Element
         The lxml node pointing to a medline document
-    
+
     Returns
     -------
     authors: list
@@ -426,7 +426,7 @@ def parse_references(pubmed_article, reference_list):
     pubmed_article: Element
         The lxml element pointing to a medline document
 
-    reference_list: bool 
+    reference_list: bool
         if it is True, return a list of dictionary
         if it is False return a string of PMIDs seprated by semicolon ';'
 
@@ -549,6 +549,9 @@ def parse_article_info(
     journal = article.find("Journal")
     journal_name = " ".join(journal.xpath("Title/text()"))
 
+    language_field = article.findall("Language")
+    language = [''.join(elem.itertext()) for elem in language_field]
+
     pmid = parse_pmid(pubmed_article)
     doi = parse_doi(pubmed_article)
     references = parse_references(pubmed_article, reference_list)
@@ -566,6 +569,7 @@ def parse_article_info(
         "authors": authors,
         "pubdate": pubdate,
         "pmid": pmid,
+        "language": language,
         "mesh_terms": mesh_terms,
         "publication_types": publication_types,
         "chemical_list": chemical_list,
@@ -609,7 +613,7 @@ def parse_medline_xml(
         if False, this will parse structured abstract where each section will be assigned to
         NLM category of each sections
         default: False
-    author_list: bool 
+    author_list: bool
         if True, return parsed author output as a list of authors
         if False, return parsed author output as a string of authors concatenated with ``;``
         default: False

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -343,9 +343,9 @@ def parse_author_affiliation(medline):
                 else:
                     forename = ""
                 if author.find("Initials") is not None:
-                    firstname = (author.find("Initials").text or "").strip() or ""
+                    initials = (author.find("Initials").text or "").strip() or ""
                 else:
-                    firstname = ""
+                    initials = ""
                 if author.find("LastName") is not None:
                     lastname = (author.find("LastName").text or "").strip() or ""
                 else:
@@ -360,10 +360,10 @@ def parse_author_affiliation(medline):
                     affiliation = ""
                 authors.append(
                     {
-                        "forename": forename,
-                        "firstname": firstname,
-                        "lastname": lastname,
-                        "affiliation": affiliation,
+                        "LastName": lastname,
+                        "ForeName": forename,
+                        "Initials": initials,
+                        "Affiliation": affiliation,
                     }
                 )
     return authors

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -781,6 +781,27 @@ def parse_medline_xml(
     return article_list
 
 
+def get_medline_tree(path):
+    """Initial parsing of the xml file tree. Finds all the articles.
+
+    Parameters
+    ----------
+    path: str
+        The path
+
+    Return
+    ------
+    medline_citations: list
+        A list of lxml.etree._Element, each being a pubmed article
+    """
+    tree = read_xml(path)
+    medline_citations = tree.findall("//MedlineCitationSet/MedlineCitation")
+    if len(medline_citations) == 0:
+        medline_citations = tree.findall("//PubmedArticle")
+
+    return medline_citations
+
+
 def parse_medline_xml_abcam(path, include_deleted=False):
     """Parse XML file frxoxm Medline XML format available at
     ftp://ftp.nlm.nih.gov/nlmdata/.medleasebaseline/gz/
@@ -807,10 +828,7 @@ def parse_medline_xml_abcam(path, include_deleted=False):
     >>> pubmed_parser.parse_medline_xml_abcam('data/pubmed20n0014.xml.gz')
     """
 
-    tree = read_xml(path)
-    medline_citations = tree.findall("//MedlineCitationSet/MedlineCitation")
-    if len(medline_citations) == 0:
-        medline_citations = tree.findall("//PubmedArticle")
+    medline_citations = get_medline_tree(path)
     article_list = list(
         map(lambda m: parse_article_info_abcam(m), medline_citations)
     )

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -6,6 +6,7 @@ import numpy as np
 from itertools import chain
 from collections import defaultdict
 from pubmed_parser.utils import read_xml, stringify_children, month_or_day_formater
+import lxml
 
 __all__ = ["parse_medline_xml", "parse_medline_grant_id"]
 
@@ -781,13 +782,16 @@ def parse_medline_xml(
     return article_list
 
 
-def get_medline_tree(path):
+def get_medline_tree(path, to_string=False):
     """Initial parsing of the xml file tree. Finds all the articles.
 
     Parameters
     ----------
     path: str
         The path
+
+    to_string: bool
+        If True, return a list of string elements
 
     Return
     ------
@@ -798,6 +802,9 @@ def get_medline_tree(path):
     medline_citations = tree.findall("//MedlineCitationSet/MedlineCitation")
     if len(medline_citations) == 0:
         medline_citations = tree.findall("//PubmedArticle")
+
+    if to_string:
+        return [lxml.etree.tostring(elem) for elem in medline_citations]
 
     return medline_citations
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 if __name__ == "__main__":
     setup(
         name="pubmed_parser",
-        version="0.2.2",
+        version="0.2.3-cts",
         description="A python parser for Pubmed Open-Access Subset and MEDLINE XML repository",
         url="https://github.com/titipata/pubmed_parser",
         download_url="https://github.com/titipata/pubmed_parser.git",

--- a/tests/test_medline_parser.py
+++ b/tests/test_medline_parser.py
@@ -20,6 +20,8 @@ def test_parse_medline_xml():
     assert parsed_medline[0]["title"][0:50] == expected_title
     assert parsed_medline[0]["abstract"][0:50] == expected_abstract
     assert parsed_medline[0]["pmid"] == "399296"
+    assert parsed_medline[0]["language"] == ["eng"]
+    assert parsed_medline[965]["language"] == ["fre", "ger"]
 
 
 def test_parse_medline_grant_id():

--- a/tests/test_medline_parser.py
+++ b/tests/test_medline_parser.py
@@ -24,6 +24,31 @@ def test_parse_medline_xml():
     assert parsed_medline[965]["language"] == ["fre", "ger"]
 
 
+def test_parse_medline_xml_abcam():
+    """
+    Test parsing MEDLINE XML - Abcam version
+    """
+
+    expected_title = "Monitoring of bacteriological contamination and as"
+    expected_abstract = "Two hundred and sixty nine beef, 230 sheep and 165"
+
+    parsed_medline = pp.parse_medline_xml_abcam(os.path.join("data", "pubmed20n0014.xml.gz"))
+
+    assert isinstance(parsed_medline, list)
+    assert len(parsed_medline) == 30000, "Expect to have 30000 records"
+    assert (len([p for p in parsed_medline if len(p["Title"]) > 0]) == 30000), "Expect every records to have title"
+
+    assert parsed_medline[0]["Title"][0:50] == expected_title
+    assert parsed_medline[0]["Abstract"][0:50] == expected_abstract
+    assert parsed_medline[0]["PMID"] == "399296"
+    assert parsed_medline[0]["Language"] == ["eng"]
+    assert parsed_medline[965]["Language"] == ["fre", "ger"]
+    assert parsed_medline[23]['Year'] == '1979'
+    assert parsed_medline[31]['DOI'] == '10.1038/281646a0'
+    assert parsed_medline[33]['Journal'] == 'Nature'
+    assert parsed_medline[33]['JournalAbv'] == 'Nature'
+
+
 def test_parse_medline_grant_id():
     """
     Test parsing grants from MEDLINE XML


### PR DESCRIPTION
Improve serialization by adding a `encoding` keyword to `get_medline_tree`