### PR TITLE
Fixing SyntaxError in issue #49

### DIFF
--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -630,9 +630,9 @@ def parse_medline_xml(
     >>> pubmed_parser.parse_medline_xml('data/pubmed20n0014.xml.gz')
     """
     tree = read_xml(path)
-    medline_citations = tree.findall("//MedlineCitationSet/MedlineCitation")
+    medline_citations = tree.findall(".//MedlineCitationSet/MedlineCitation")
     if len(medline_citations) == 0:
-        medline_citations = tree.findall("//PubmedArticle")
+        medline_citations = tree.findall(".//PubmedArticle")
     article_list = list(
         map(
             lambda m: parse_article_info(
@@ -641,7 +641,7 @@ def parse_medline_xml(
             medline_citations,
         )
     )
-    delete_citations = tree.findall("//DeleteCitation/PMID")
+    delete_citations = tree.findall(".//DeleteCitation/PMID")
     dict_delete = [
         {
             "title": np.nan,
@@ -696,9 +696,9 @@ def parse_medline_grant_id(path):
     ]
     """
     tree = read_xml(path)
-    medline_citations = tree.findall("//MedlineCitationSet/MedlineCitation")
+    medline_citations = tree.findall(".//MedlineCitationSet/MedlineCitation")
     if len(medline_citations) == 0:
-        medline_citations = tree.findall("//PubmedArticle")
+        medline_citations = tree.findall(".//PubmedArticle")
     grant_id_list = list(map(parse_grant_id, medline_citations))
     grant_id_list = list(chain(*grant_id_list))  # flatten list
     return grant_id_list

--- a/pubmed_parser/utils.py
+++ b/pubmed_parser/utils.py
@@ -29,6 +29,8 @@ def read_xml(path, nxml=False):
     """
     try:
         tree = etree.parse(path)
+        if ".nxml" in path or nxml:
+            remove_namespace(tree)  # strip namespace when reading an XML file
     except:
         try:
             tree = etree.fromstring(path)
@@ -37,8 +39,6 @@ def read_xml(path, nxml=False):
                 "Error: it was not able to read a path, a file-like object, or a string as an XML"
             )
             raise
-    if ".nxml" in path or nxml:
-        remove_namespace(tree)  # strip namespace when reading an XML file
     return tree
 
 


### PR DESCRIPTION
was trying to read pubmed data from string and ran into 2 errors:

* `tree = etree.fromstring(path)` require bytes-like object which will cause an error in 
```
if ".nxml" in path or nxml:
    remove_namespace(tree)  # strip namespace when reading an XML file
```
 
* same as #49 

This merge will fix them.