### PR TITLE
Added issue, page number, and firstname to medline_parse_xml()

### DIFF
--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -325,7 +325,7 @@ def parse_author_affiliation(medline):
     ----------
     medline: Element
         The lxml node pointing to a medline document
-    
+
     Returns
     -------
     authors: list
@@ -350,6 +350,10 @@ def parse_author_affiliation(medline):
                     lastname = (author.find("LastName").text or "").strip() or ""
                 else:
                     lastname = ""
+                if author.find("Identifier") is not None:
+                    identifier = (author.find("Identifier").text or "").strip() or ""
+                else:
+                    identifier = ""
                 if author.find("AffiliationInfo/Affiliation") is not None:
                     affiliation = author.find("AffiliationInfo/Affiliation").text or ""
                     affiliation = affiliation.replace(
@@ -363,6 +367,7 @@ def parse_author_affiliation(medline):
                         "forename": forename,
                         "firstname": firstname,
                         "lastname": lastname,
+                        "identifier": identifier,
                         "affiliation": affiliation,
                     }
                 )
@@ -426,7 +431,7 @@ def parse_references(pubmed_article, reference_list):
     pubmed_article: Element
         The lxml element pointing to a medline document
 
-    reference_list: bool 
+    reference_list: bool
         if it is True, return a list of dictionary
         if it is False return a string of PMIDs seprated by semicolon ';'
 
@@ -540,7 +545,8 @@ def parse_article_info(
         )
         authors = ";".join(
             [
-                author.get("firstname", "") + " " + author.get("lastname", "")
+                author.get("firstname", "") + "|" + author.get("lastname",   "") + "|" +
+                author.get("initials",  "") + "|" + author.get("identifier", "")
                 for author in authors_dict
             ]
         )
@@ -609,7 +615,7 @@ def parse_medline_xml(
         if False, this will parse structured abstract where each section will be assigned to
         NLM category of each sections
         default: False
-    author_list: bool 
+     author_list: bool
         if True, return parsed author output as a list of authors
         if False, return parsed author output as a string of authors concatenated with ``;``
         default: False

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -522,7 +522,9 @@ def parse_article_info(
     else:
         issue = ""
 
-    if volume != "":
+    if volume == "":
+        issue = ""
+    else:
         issue = f"{volume}({issue})"
 
     if article.find("Pagination/MedlinePgn") is not None:

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -500,7 +500,7 @@ def parse_article_info(
     article: dict
         Dictionary containing information about the article, including
         `title`, `abstract`, `journal`, `authors`, `affiliations`, `pubdate`,
-        `pmid`, `other_id`, `mesh_terms`, and `keywords`. The field
+        `pmid`, `other_id`, `mesh_terms`, `pages`, `issue`, and `keywords`. The field
         `delete` is always `False` because this function parses
         articles that by definition are not deleted.
     """
@@ -511,6 +511,24 @@ def parse_article_info(
         title = stringify_children(article.find("ArticleTitle")).strip() or ""
     else:
         title = ""
+
+    if article.find("Journal/JournalIssue/Volume") is not None:
+        volume = article.find("Journal/JournalIssue/Volume").text or ""
+    else:
+        volume = ""
+
+    if article.find("Journal/JournalIssue/Issue") is not None:
+        issue = article.find("Journal/JournalIssue/Issue").text or ""
+    else:
+        issue = ""
+
+    if volume != "":
+        issue = f"{volume}({issue})"
+
+    if article.find("Pagination/MedlinePgn") is not None:
+        pages = article.find("Pagination/MedlinePgn").text or ""
+    else:
+        pages = ""
 
     category = "NlmCategory" if nlm_category else "Label"
     if article.find("Abstract/AbstractText") is not None:
@@ -567,6 +585,8 @@ def parse_article_info(
     journal_info_dict = parse_journal_info(medline)
     dict_out = {
         "title": title,
+        "issue": issue,
+        "pages": pages,
         "abstract": abstract,
         "journal": journal_name,
         "authors": authors,

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -343,9 +343,9 @@ def parse_author_affiliation(medline):
                 else:
                     forename = ""
                 if author.find("Initials") is not None:
-                    firstname = (author.find("Initials").text or "").strip() or ""
+                    initials = (author.find("Initials").text or "").strip() or ""
                 else:
-                    firstname = ""
+                    initials = ""
                 if author.find("LastName") is not None:
                     lastname = (author.find("LastName").text or "").strip() or ""
                 else:
@@ -364,9 +364,9 @@ def parse_author_affiliation(medline):
                     affiliation = ""
                 authors.append(
                     {
-                        "forename": forename,
-                        "firstname": firstname,
                         "lastname": lastname,
+                        "forename": forename,
+                        "initials": initials,
                         "identifier": identifier,
                         "affiliation": affiliation,
                     }
@@ -545,7 +545,7 @@ def parse_article_info(
         )
         authors = ";".join(
             [
-                author.get("firstname", "") + "|" + author.get("lastname",   "") + "|" +
+                author.get("lastname", "") + "|" + author.get("forename",   "") + "|" +
                 author.get("initials",  "") + "|" + author.get("identifier", "")
                 for author in authors_dict
             ]

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -692,6 +692,8 @@ def parse_medline_xml(
             "issn_linking": np.nan,
             "country": np.nan,
             "references": np.nan,
+            "issue": np.nan,
+            "pages": np.nan,
         }
         for p in delete_citations
     ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 if __name__ == "__main__":
     setup(
         name="pubmed_parser",
-        version="0.2.2",
+        version="0.3.0",
         description="A python parser for Pubmed Open-Access Subset and MEDLINE XML repository",
         url="https://github.com/titipata/pubmed_parser",
         download_url="https://github.com/titipata/pubmed_parser.git",

--- a/tests/test_medline_parser.py
+++ b/tests/test_medline_parser.py
@@ -18,6 +18,8 @@ def test_parse_medline_xml():
         len([p for p in parsed_medline if len(p["title"]) > 0]) == 30000
     ), "Expect every records to have title"
     assert parsed_medline[0]["title"][0:50] == expected_title
+    assert parsed_medline[0]["issue"] == "50(2)"
+    assert parsed_medline[0]["pages"] == "123-33"
     assert parsed_medline[0]["abstract"][0:50] == expected_abstract
     assert parsed_medline[0]["pmid"] == "399296"
 


### PR DESCRIPTION
1. `forename` and `initials` are tricky. Before the parser returned `firstname` with values from `initials` tag text. In this change, the parse function returns both `forename` and `initials`. Because this changes the dictionary keys returned by the parser, I bumped the version number. In the XML, initials is the initials of the forename, not the whole name.
Before: 
`{ "firstname": "JP", "lastname": "Smith" ... }` 
After 
`{ "forename": "John Paul", "initials": "JP", "lastname": "Smith" ... }`

1. Added `issue` that combines volume and issue info. For example `"issue": "50(2)"`. 

1. Added `pages` returned and pulled from the `Pagination/MedlinePgn` tag text.

1. I added a test for the issue and page number addition. 

Thanks for open sourcing this @titipata 
