### PR TITLE
Fix syntax error: `not in ""`. 

### DIFF
--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -472,7 +472,7 @@ def parse_references(pubmed_article, reference_list):
         return references
     else:
         references = ";".join(
-            [ref["pmid"] for ref in references if ref["pmid"] is not ""]
+            [ref["pmid"] for ref in references if ref["pmid"] != ""]
         )
         return references
 

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -560,7 +560,7 @@ def parse_article_info(
             [
                 author.get("affiliation", "")
                 for author in authors_dict
-                if author.get("affiliation", "") is not ""
+                if author.get("affiliation", "") != ""
             ]
         )
         authors = ";".join(


### PR DESCRIPTION
related with issue: https://github.com/titipata/pubmed_parser/issues/104

There is a syntax error in `medline_parser`. Only needs a one line quick fix, AFAIK. 