### PR TITLE
add Language and VernacularTitle element extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ MEDLINE XML has a different XML format than PubMed Open Access. The structure of
 * `country` : Country extracted from journal information field
 * `reference` : string of PMID each separated by `;` or list of references made to the article
 * `delete` : boolean if `False` means paper got updated so you might have two
+* `languages` : list of languages, separated by `;`
+* `vernacular_title`: vernacular title. Defaults to empty string whenever non-available.
 
 XMLs for the same paper. You can delete the record of deleted paper because it got updated.
 

--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -517,6 +517,16 @@ def parse_article_info(
     else:
         volume = ""
 
+    if article.find("Language") is not None:
+        languages = ";".join([language.text for language in article.findall("Language")])
+    else:
+        languages = ""
+
+    if article.find("VernacularTitle") is not None:
+        vernacular_title = article.find("VernacularTitle").text
+    else:
+        vernacular_title = ""
+
     if article.find("Journal/JournalIssue/Issue") is not None:
         issue = article.find("Journal/JournalIssue/Issue").text or ""
     else:
@@ -601,6 +611,8 @@ def parse_article_info(
         "doi": doi,
         "references": references,
         "delete": False,
+        "languages": languages,
+        "vernacular_title": vernacular_title
     }
     if not author_list:
         dict_out.update({"affiliations": affiliations})
@@ -694,6 +706,8 @@ def parse_medline_xml(
             "references": np.nan,
             "issue": np.nan,
             "pages": np.nan,
+            "languages": np.nan,
+            "vernacular_title": np.nan
         }
         for p in delete_citations
     ]

--- a/tests/test_medline_parser.py
+++ b/tests/test_medline_parser.py
@@ -22,6 +22,8 @@ def test_parse_medline_xml():
     assert parsed_medline[0]["pages"] == "123-33"
     assert parsed_medline[0]["abstract"][0:50] == expected_abstract
     assert parsed_medline[0]["pmid"] == "399296"
+    assert parsed_medline[0]["languages"] == "eng"
+    assert parsed_medline[0]["vernacular_title"] == ""
 
 
 def test_parse_medline_grant_id():


### PR DESCRIPTION
Language information and associated vernacular titles are useful information for people working in NLP and looking to extract documents in other languages than English. I added this feature to the code and wrote associated description and tests.

Here is the fine-grained description of the changes:
- I added the extraction of Language XML elements from PubMed/MEDLINE citations. Defaults to empty string whenever non-available.
- Whenever available (i.e. when the language is not english), I added the extraction of the VenacularTitle element. Defaults to empty string whenever non-available.
- I updated the README to reflect these changes.
- I updated the medline_parser test to reflect these changes. All tests pass.