### PR TITLE
bug correction for vernacular title extraction

### DIFF
--- a/pubmed_parser/medline_parser.py
+++ b/pubmed_parser/medline_parser.py
@@ -523,7 +523,7 @@ def parse_article_info(
         languages = ""
 
     if article.find("VernacularTitle") is not None:
-        vernacular_title = article.find("VernacularTitle").text
+        vernacular_title = stringify_children(article.find("VernacularTitle")).strip() or ""
     else:
         vernacular_title = ""
 


### PR DESCRIPTION
VernacularTitle elements can be composed of several sub-elements. We use stringify_children() to extract the textual content.