### PR TITLE
fix git install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Identifiers should be passed as strings. PubMed Central ID's are default, and sh
 You can install the most update version of the package directly from the repository
 
 ``` bash
-pip install git+git://github.com/titipata/pubmed_parser.git
+pip install git+https://github.com/titipata/pubmed_parser.git
 ```
 
 or install recent release with [PyPI](https://pypi.org/project/pubmed-parser/) using


### PR DESCRIPTION
The git:// url is no longer supported. See for example https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported