### PR TITLE
turn parse_medline_xml into an iterator to save memory

### DIFF
--- a/pubmed_parser/__init__.py
+++ b/pubmed_parser/__init__.py
@@ -12,7 +12,7 @@ from .pubmed_oa_parser import (
     parse_pubmed_caption,
     parse_pubmed_table,
 )
-from .medline_parser import parse_medline_xml, parse_medline_grant_id, split_mesh
+from .medline_parser import parse_medline_xml, split_mesh
 from .pubmed_web_parser import (
     parse_xml_web,
     parse_citation_web,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 if __name__ == "__main__":
     setup(
         name="pubmed_parser",
-        version="0.3.1",
+        version="0.4.0",
         description="A python parser for Pubmed Open-Access Subset and MEDLINE XML repository",
         url="https://github.com/titipata/pubmed_parser",
         download_url="https://github.com/titipata/pubmed_parser.git",


### PR DESCRIPTION
This PR makes two main changes:

1. Adds grant parsing into the primary parser and embeds the results into the main PubMed record.
2. Converts the parse_medline_xml into an iterator. The largest pubmednXX file uses about 7GB to parse, so this change allows one to reduce memory usage considerably.

I haven't added tests or detailed examples, and this is a significant change to the API and internal behavior, so feel free to ignore the PR. 

Finally, thanks for making a really useful piece of software available to the rest of us!