### PR TITLE
#135 Fix: Use doi from`ELocationID` insted of `ArticleIdList\\ArticleId`

### DIFF
--- a/pubmed_parser/pubmed_web_parser.py
+++ b/pubmed_parser/pubmed_web_parser.py
@@ -132,12 +132,11 @@ def parse_pubmed_web_tree(tree):
     else:
         keywords = ""
 
-    doi = ""
-    article_ids = tree.xpath("//elocationid")
-    if len(article_ids) >= 1:
-        for article_id in article_ids:
-            if article_id.attrib.get("eidtype") == "doi":
-                doi = article_id.text
+    doi = tree.xpath('//elocationid[@eidtype="doi"]')
+    try:
+        doi = doi[0].text
+    except IndexError:
+        doi = None
     
     language = tree.xpath("//language")
     try:

--- a/pubmed_parser/pubmed_web_parser.py
+++ b/pubmed_parser/pubmed_web_parser.py
@@ -133,10 +133,10 @@ def parse_pubmed_web_tree(tree):
         keywords = ""
 
     doi = ""
-    article_ids = tree.xpath("//articleidlist//articleid")
+    article_ids = tree.xpath("//elocationid")
     if len(article_ids) >= 1:
         for article_id in article_ids:
-            if article_id.attrib.get("idtype") == "doi":
+            if article_id.attrib.get("eidtype") == "doi":
                 doi = article_id.text
     
     language = tree.xpath("//language")

--- a/tests/test_pubmed_web_parser.py
+++ b/tests/test_pubmed_web_parser.py
@@ -65,3 +65,8 @@ def test_pubmed_web_parser_save_xml():
     pubmed_dict = pp.parse_xml_web(random_id, save_xml=True)
     
     assert "xml" in pubmed_dict
+
+def test_doi():
+    """Test the correct parsing of the doi."""
+    pubmed_dict = pp.parse_xml_web("32145645", save_xml=False)
+    assert pubmed_dict['doi'] == "10.1016/j.ejmech.2020.112186"


### PR DESCRIPTION
 Use doi from`ELocationID` insted of `ArticleIdList\\ArticleId`