### PR TITLE
Accomodate date-type in parse_date

### DIFF
--- a/pubmed_parser/pubmed_oa_parser.py
+++ b/pubmed_parser/pubmed_oa_parser.py
@@ -92,10 +92,15 @@ def parse_date(tree, date_type):
     def get_text(node):
         return node.text if node is not None else None
 
-    pub_date_path = f".//pub-date[@pub-type=\"{date_type}\"]"
+    pub_date_path = f".//pub-date[@pub-type='{date_type}' or @date-type='{date_type}']"
+    date_node = tree.xpath(pub_date_path)
+    
+    if not date_node:
+        return {}
+
     date_dict = {}
     for part in ["year", "month", "day"]:
-        text = get_text(tree.find(f"{pub_date_path}/{part}"))
+        text = get_text(date_node[0].find(part))
         if text is not None:
             date_dict[part] = text
 


### PR DESCRIPTION
180/955 articles in oa_comm_xml.incr.2024-10-04 had dates recorded like: 
```<pub-date date-type="collection" publication-format="electronic"><month>9</month><year>2024</year></pub-date>```
instead of 
```
<pub-date pub-type="collection" publication-format="electronic"><month>9</month><year>2024</year></pub-date>
```
these changes will now properly parse those dates and not error on parsing the whole document