### PR TITLE
missing comma breaking install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Natural Language :: English",
-    "Topic :: Documentation :: Sphinx"
+    "Topic :: Documentation :: Sphinx",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Missing comma was breaking install via PIP. 
